### PR TITLE
Change step size of conv filter count

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
             </div>
             <h4>Convolution</h4>
             <div id="convolution_parameters">
-                <label class="k">Filter Count <em>K</em><input type="range" min=4 max=128 step=4 value=4></input></label>
+                <label class="k">Filter Count <em>K</em><input type="range" min=4 max=128 step=1 value=4></input></label>
                 <label class="f">Spatial Extent <em>F</em><input type="range" min=1 max=9 step=1 value=3></input></label>
                 <label class="s">Stride <em>S</em><input type="range" min=1 max=10 step=1 value=1></input></label>
                 <label class="p">Zero Padding <em>P</em><input type="range" min=0 max=8 step=0 value=0></input></label>


### PR DESCRIPTION
## Issue
The output depth has a step size of 4, so for a filter count of e.g. 6, the output depth is displayed as 8.

## Changes
I changed the step size for the filter count in ``index.html`` to 1, so the filter count and output depth always match.